### PR TITLE
feat: Show players in game

### DIFF
--- a/nettank-client/src/main/java/org/chrisgruber/nettank/client/engine/ui/KillFeedMessage.java
+++ b/nettank-client/src/main/java/org/chrisgruber/nettank/client/engine/ui/KillFeedMessage.java
@@ -1,7 +1,11 @@
 package org.chrisgruber.nettank.client.engine.ui;
 
-public record KillFeedMessage(String message, long expiryTimeMillis) {
+public record KillFeedMessage(StatusMessageKind statusMessageKind, String message, long expiryTimeMillis) {
     public boolean isExpired() {
         return System.currentTimeMillis() >= expiryTimeMillis;
+    }
+
+    public StatusMessageKind getStatusMessageKind() {
+        return statusMessageKind;
     }
 }

--- a/nettank-client/src/main/java/org/chrisgruber/nettank/client/engine/ui/StatusMessageKind.java
+++ b/nettank-client/src/main/java/org/chrisgruber/nettank/client/engine/ui/StatusMessageKind.java
@@ -1,0 +1,7 @@
+package org.chrisgruber.nettank.client.engine.ui;
+
+public enum StatusMessageKind {
+    PlayerKilled,
+    PlayerLeft,
+    PlayerJoined
+}

--- a/nettank-client/src/main/java/org/chrisgruber/nettank/client/game/TankBattleGame.java
+++ b/nettank-client/src/main/java/org/chrisgruber/nettank/client/game/TankBattleGame.java
@@ -93,7 +93,7 @@ public class TankBattleGame extends GameEngine implements NetworkCallbackHandler
     private boolean prevKeyD = false;
 
     // Config
-    public static final float VIEW_RANGE = 300.0f;
+    public static final float VIEW_RANGE = 400.0f;
 
     // Game world map
     private int mapWidthTiles = -1;

--- a/nettank-client/src/main/resources/logback.xml
+++ b/nettank-client/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
     </appender>
 
     <!-- Root logger with both appenders -->
-    <root level="debug">
+    <root level="INFO">
         <appender-ref ref="CONSOLE" />
         <appender-ref ref="FILE" />
     </root>

--- a/nettank-server/src/main/java/org/chrisgruber/nettank/server/GameServer.java
+++ b/nettank-server/src/main/java/org/chrisgruber/nettank/server/GameServer.java
@@ -463,7 +463,11 @@ public class GameServer {
         String targetName = target.getPlayerName();
         logger.info("Hit registered: {} -> {}", shooterName, targetName);
 
-        // TODO: implement weapon damage and ammo
+        if (target.isDestroyed()) {
+            logger.debug("Hit ignored: {} is already destroyed.", targetName);
+            return;
+        }
+
         int weaponDamage = 1;
         target.takeHit(weaponDamage);
 

--- a/nettank-server/src/main/java/org/chrisgruber/nettank/server/GameServer.java
+++ b/nettank-server/src/main/java/org/chrisgruber/nettank/server/GameServer.java
@@ -38,8 +38,8 @@ public class GameServer {
     public static final long TANK_SHOOT_COOLDOWN_MS = 500;
 
     // Game World Map
-    public static final int MAP_WIDTH = 100;
-    public static final int MAP_HEIGHT = 100;
+    public static final int MAP_WIDTH = 50;
+    public static final int MAP_HEIGHT = 50;
 
     private final List<Vector3f> availableColors;
     private final List<Thread> clientHandlerThreads = new CopyOnWriteArrayList<>();

--- a/nettank-server/src/main/resources/logback.xml
+++ b/nettank-server/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
 
     <!-- Set root logger level and add appenders -->
     <!-- Use DEBUG or TRACE for more detail during development -->
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
     </root>


### PR DESCRIPTION
1. Show count of players in game
2. Show in game messages when players join or leave the game
3. Reduce default game world map size to 50 by 50 tiles
4. Increase fog of war range
5. Do not count hits onboard already destroyed tanks as an earned kill