### PR TITLE
fix: Remove collided tank shots

### DIFF
--- a/nettank-client/src/main/java/org/chrisgruber/nettank/client/engine/network/GameClient.java
+++ b/nettank-client/src/main/java/org/chrisgruber/nettank/client/engine/network/GameClient.java
@@ -10,6 +10,7 @@ import java.io.*;
 import java.net.Socket;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.UUID;
 
 public class GameClient implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(GameClient.class);
@@ -206,27 +207,30 @@ public class GameClient implements Runnable {
                     }
                     break;
                 case NetworkProtocol.SHOOT:
-                    // SHO;<ownerId>;<x>;<y>;<dirX>;<dirY> (6 parts now)
-                    if (parts.length >= 6) {
-                        int ownerId = Integer.parseInt(parts[1]);
-                        float x = Float.parseFloat(parts[2]);
-                        float y = Float.parseFloat(parts[3]);
-                        float dirX = Float.parseFloat(parts[4]);
-                        float dirY = Float.parseFloat(parts[5]);
-                        networkCallbackHandler.spawnBullet(ownerId, x, y, dirX, dirY);
+                    // SHO;<bulletId>;<ownerId>;<x>;<y>;<dirX>;<dirY> (6 parts now)
+                    if (parts.length >= 7) {
+                        UUID bulletId = UUID.fromString(parts[1]);
+                        int ownerId = Integer.parseInt(parts[2]);
+                        float x = Float.parseFloat(parts[3]);
+                        float y = Float.parseFloat(parts[4]);
+                        float dirX = Float.parseFloat(parts[5]);
+                        float dirY = Float.parseFloat(parts[6]);
+                        networkCallbackHandler.spawnBullet(bulletId, ownerId, x, y, dirX, dirY);
                     } else {
-                        logger.error("Malformed SHOOT message: Expected 6 parts, got {}", parts.length);
+                        logger.error("Malformed SHOOT message: Expected 7 parts, got {}", parts.length);
                     }
                     break;
                 case NetworkProtocol.HIT:
-                    // HIT;<targetId>;<shooterId> (3 parts)
-                    if (parts.length >= 3) {
+                    // HIT;<targetId>;<shooterId>;<bulletId>;<damage> (5 parts)
+                    if (parts.length >= 5) {
                         int t = Integer.parseInt(parts[1]);
                         int s = Integer.parseInt(parts[2]);
-                        networkCallbackHandler.handlePlayerHit(t, s);
+                        UUID uuid = UUID.fromString(parts[3]);
+                        int damage = Integer.parseInt(parts[4]);
+                        networkCallbackHandler.handlePlayerHit(t, s, uuid, damage);
                     }
                     else {
-                        logger.error("Malformed HIT message: Expected 3 parts, got {}", parts.length);
+                        logger.error("Malformed HIT message: Expected 5 parts, got {}", parts.length);
                     }
                     break;
                 case NetworkProtocol.DESTROYED:

--- a/nettank-client/src/main/java/org/chrisgruber/nettank/client/engine/network/GameClient.java
+++ b/nettank-client/src/main/java/org/chrisgruber/nettank/client/engine/network/GameClient.java
@@ -288,19 +288,17 @@ public class GameClient implements Runnable {
                     }
                     break;
                 case NetworkProtocol.RESPAWN:
-                    // RSP;<id>;<x>;<y> (4 parts)
-                    if (parts.length >= 4) {
+                    // RSP;<id>;<x>;<y>;<rotation> (5 parts)
+                    if (parts.length >= 5) {
                         int id = Integer.parseInt(parts[1]);
                         float x = Float.parseFloat(parts[2]);
                         float y = Float.parseFloat(parts[3]);
-                        // setForSpawn likely implies full health and update position/rotation (rot=0?)
-                        // We can reuse updateTankState for position, and updatePlayerLives separately
-                        // Server sends PLAYER_LIVES after RSP anyway in resetPlayersForNewRound
+                        float rotation = Float.parseFloat(parts[4]);
                         logger.debug("Received RESPAWN for player {}", id);
-                        networkCallbackHandler.updateTankState(id, x, y, 0); // Reset rotation to 0 on respawn?
+                        networkCallbackHandler.updateTankState(id, x, y, rotation);
                         // Server will send PLAYER_LIVES shortly after
                     } else {
-                        logger.error("Malformed RESPAWN message: Expected 4 parts, got {}", parts.length);
+                        logger.error("Malformed RESPAWN message: Expected 5 parts, got {}", parts.length);
                     }
                     break;
                 case NetworkProtocol.SPECTATE_START:

--- a/nettank-client/src/main/java/org/chrisgruber/nettank/client/engine/network/NetworkCallbackHandler.java
+++ b/nettank-client/src/main/java/org/chrisgruber/nettank/client/engine/network/NetworkCallbackHandler.java
@@ -2,6 +2,8 @@ package org.chrisgruber.nettank.client.engine.network;
 
 import org.chrisgruber.nettank.common.util.GameState;
 
+import java.util.UUID;
+
 public interface NetworkCallbackHandler {
     // Connection Status
     void connectionFailed(String reason);
@@ -15,8 +17,8 @@ public interface NetworkCallbackHandler {
     void updateTankState(int id, float x, float y, float rotation);
     void removeTank(int id);
     void updatePlayerLives(int playerId, int lives);
-    void spawnBullet(int ownerId, float x, float y, float dirX, float dirY);
-    void handlePlayerHit(int targetId, int shooterId);
+    void spawnBullet(UUID bulletId, int ownerId, float x, float y, float dirX, float dirY);
+    void handlePlayerHit(int targetId, int shooterId, UUID bulletId, int damage);
     void handlePlayerDestroyed(int targetId, int shooterId);
     void storeMapInfo(int widthTiles, int heightTiles, float tileSize);
 }

--- a/nettank-client/src/main/java/org/chrisgruber/nettank/client/game/entities/ClientBullet.java
+++ b/nettank-client/src/main/java/org/chrisgruber/nettank/client/game/entities/ClientBullet.java
@@ -4,9 +4,11 @@ import org.chrisgruber.nettank.common.entities.BulletData; // Use common data
 import org.chrisgruber.nettank.common.entities.Entity;
 import org.joml.Vector2f;
 
+import java.util.UUID;
+
 public class ClientBullet extends Entity {
 
-    private final BulletData bulletData; // Holds initial state + client spawn time
+    private final BulletData bulletData;
 
     public ClientBullet(BulletData data) {
         super(data.getPlayerId(), data.getPosition(), BulletData.SIZE, BulletData.SIZE, data.getVelocity(), data.getRotation());
@@ -49,7 +51,8 @@ public class ClientBullet extends Entity {
 
     // Getters for rendering/logic
     public long getSpawnTime() { return bulletData.getSpawnTime(); }
-    public int getOwnerId() { return bulletData.getPlayerId(); }
+    public boolean isDestroyed() { return bulletData.isDestroyed(); }
+    public UUID getId() { return bulletData.getId(); }
 
     public BulletData getBulletData() {
         return bulletData;

--- a/nettank-common/src/main/java/org/chrisgruber/nettank/common/entities/BulletData.java
+++ b/nettank-common/src/main/java/org/chrisgruber/nettank/common/entities/BulletData.java
@@ -4,6 +4,8 @@ import org.joml.Vector2f;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.UUID;
+
 public class BulletData extends Entity {
     private static final Logger logger = LoggerFactory.getLogger(BulletData.class);
     public static final float SIZE = 15.0f; // Size of the bullet in pixels
@@ -11,10 +13,14 @@ public class BulletData extends Entity {
     public static final long LIFETIME_MS = 2000; // Max travel time in ms
 
     protected long spawnTime;
+    protected boolean isDestroyed;
+    protected UUID id;
 
-    public BulletData(int playerId, Vector2f position, Vector2f velocity, float rotation, long spawnTime) {
+    public BulletData(UUID id, int playerId, Vector2f position, Vector2f velocity, float rotation, long spawnTime, boolean isDestroyed) {
         super(playerId, position, SIZE, SIZE, velocity, rotation);
         this.spawnTime = spawnTime;
+        this.isDestroyed = isDestroyed;
+        this.id = id;
     }
 
     @Override
@@ -30,4 +36,12 @@ public class BulletData extends Entity {
     public long getSpawnTime() { return spawnTime; }
 
     public void setSpawnTime(long spawnTime) { this.spawnTime = spawnTime; }
+
+    public boolean isDestroyed() { return isDestroyed; }
+
+    public void setDestroyed(boolean destroyed) { this.isDestroyed = destroyed; }
+
+    public UUID getId() { return id; }
+
+    public void setId(UUID id) { this.id = id; }
 }

--- a/nettank-common/src/main/java/org/chrisgruber/nettank/common/network/NetworkProtocol.java
+++ b/nettank-common/src/main/java/org/chrisgruber/nettank/common/network/NetworkProtocol.java
@@ -17,7 +17,7 @@ public class NetworkProtocol {
     public static final String SHOOT = "SHO";        // SHO;<bulletId>;<ownerId>;<x>;<y>;<dirX>;<dirY>
     public static final String HIT = "HIT";          // HIT;<targetId>;<shooterId>;<bulletId>;<damage>
     public static final String DESTROYED = "DES";    // DES;<targetId>;<shooterId>
-    public static final String RESPAWN = "RSP";      // RSP;<id>;<x>;<y>
+    public static final String RESPAWN = "RSP";      // RSP;<id>;<x>;<y>;<rotation>
     public static final String PLAYER_LIVES = "LIV"; // LIV;<id>;<lives>
     public static final String GAME_STATE = "GST";   // GST;<stateName>;<timeData>
     public static final String ANNOUNCE = "ANN";     // ANN;<messageText>

--- a/nettank-common/src/main/java/org/chrisgruber/nettank/common/network/NetworkProtocol.java
+++ b/nettank-common/src/main/java/org/chrisgruber/nettank/common/network/NetworkProtocol.java
@@ -14,8 +14,8 @@ public class NetworkProtocol {
     public static final String NEW_PLAYER = "NEW";   // NEW;<id>;<x>;<y>;<rot>;<name>;<r>;<g>;<b> // Lives sent separately
     public static final String PLAYER_UPDATE = "UPD"; // UPD;<id>;<x>;<y>;<rot>
     public static final String PLAYER_LEFT = "LEF";  // LEF;<id>
-    public static final String SHOOT = "SHO";        // SHO;<ownerId>;<x>;<y>;<dirX>;<dirY>
-    public static final String HIT = "HIT";          // HIT;<targetId>;<shooterId>
+    public static final String SHOOT = "SHO";        // SHO;<bulletId>;<ownerId>;<x>;<y>;<dirX>;<dirY>
+    public static final String HIT = "HIT";          // HIT;<targetId>;<shooterId>;<bulletId>;<damage>
     public static final String DESTROYED = "DES";    // DES;<targetId>;<shooterId>
     public static final String RESPAWN = "RSP";      // RSP;<id>;<x>;<y>
     public static final String PLAYER_LIVES = "LIV"; // LIV;<id>;<lives>

--- a/nettank-server/src/main/java/org/chrisgruber/nettank/server/GameServer.java
+++ b/nettank-server/src/main/java/org/chrisgruber/nettank/server/GameServer.java
@@ -894,7 +894,7 @@ public class GameServer {
             handler.sendMessage(message);
         }
 
-        logger.info("Broadcast message sent to all clients except player ID {}: {}", excludePlayerId, message);
+        logger.trace("Broadcast message sent to all clients except player ID {}: {}", excludePlayerId, message);
     }
 
     // Broadcasts an announcement to all players, excluding the specified player IDs

--- a/nettank-server/src/main/java/org/chrisgruber/nettank/server/gamemode/FreeForAll.java
+++ b/nettank-server/src/main/java/org/chrisgruber/nettank/server/gamemode/FreeForAll.java
@@ -226,6 +226,8 @@ public class FreeForAll extends GameMode {
                     0  // Reset last shot time
             );
 
+            tankData.setInputState(false, false, false, false);
+
             tankPosition = tankData.getPosition();
             tankRotation = tankData.getRotation();
         }


### PR DESCRIPTION
This bug fix correctly despawns and removes tank shells that do collide with their target. This fix also resolves a random tank rotation bug that made the tank sometimes appear to glitch on spawn and first movement input.